### PR TITLE
fix errant references

### DIFF
--- a/AbstractConsumer.js
+++ b/AbstractConsumer.js
@@ -63,7 +63,7 @@ AbstractConsumer.prototype.init = function () {
     _this.initialize.bind(_this)
   ], function (err) {
     if (err) {
-      return this._exit(err)
+      return _this._exit(err)
     }
 
     _this._loopGetRecords()

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -56,7 +56,7 @@ try {
   process.exit(1)
 }
 
-logger.info('Spawned cluster %s', cluster.id)
+logger.info('Spawned cluster %s', cluster.cluster.id)
 
 if (args.http) {
   var port


### PR DESCRIPTION
The AbstractConsumer fix avoids an exception "Object has no method _exit" since the closure is referring to the wrong "this" object.

The lib/cli.js change fixes a display glitch that shows cluster id as "undefined" in that messages on startup. 

Great library by the way. Very useful for me.
