### PR TITLE
limit number of records retrieved from kinesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Optional flags:
 --local-kinesis (Use a local implementation of Kinesis, defaults to false)
 --local-kinesis-port (Port to access local Kinesis on, defaults to 4567)
 --local-kinesis-no-start (Assume a local Kinesis server is already running, defaults to false)
+--num-records (number of records to grab from kinesis, defaults to no limit)
 ```
 
 Notes:

--- a/src/AbstractConsumer.ts
+++ b/src/AbstractConsumer.ts
@@ -23,6 +23,7 @@ interface AbstractConsumerOpts {
   localKinesis: Boolean
   localKinesisPort?: number
   logLevel?: string
+  numRecords?: number
 }
 
 export interface ProcessRecordsCallback {
@@ -200,8 +201,13 @@ export class AbstractConsumer {
   // Get records from the stream and wait for them to be processed.
   private _getRecords (callback) {
     var _this = this
-
-    this.kinesis.getRecords({ShardIterator: this.nextShardIterator}, function (err, data) {
+    
+    var getRecordsParams = {ShardIterator: this.nextShardIterator}
+    if (this.opts.numRecords && this.opts.numRecords > 0) {
+      getRecordsParams = {ShardIterator: this.nextShardIterator, Limit: this.opts.numRecords}
+    }
+      
+    this.kinesis.getRecords(getRecordsParams, function (err, data) {
       // Handle known errors
       if (err && err.code === 'ExpiredIteratorException') {
         _this.log('Shard iterator expired, updating before next getRecords call')

--- a/src/ConsumerCluster.ts
+++ b/src/ConsumerCluster.ts
@@ -31,6 +31,7 @@ export interface ConsumerClusterOpts {
   capacity: cluster.Capacity
   startingIteratorType?: string
   logLevel?: string
+  numRecords?: number
 }
 
 
@@ -274,7 +275,8 @@ export class ConsumerCluster extends events.EventEmitter {
       leaseCounter: leaseCounter,
       localDynamo: this.opts.localDynamo,
       localKinesis: this.opts.localKinesis,
-      localKinesisPort: this.opts.localKinesisPort
+      localKinesisPort: this.opts.localKinesisPort,
+      numRecords: this.opts.numRecords
     }
 
     var env = {

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -31,6 +31,7 @@ interface KinesisCliArgs extends minimist.ParsedArgs {
   'local-kinesis-port'?: number
   'local-kinesis-no-start'?: Boolean
   'log-level': string
+  'num-records'?: number
 }
 
 var args = <KinesisCliArgs> minimist(process.argv.slice(2))
@@ -57,6 +58,7 @@ if (args.help) {
   console.log('--local-kinesis (Use a local implementation of Kinesis, defaults to false)')
   console.log('--local-kinesis-port (Port to access local Kinesis on, defaults to 4567)')
   console.log('--local-kinesis-no-start (Assume a local Kinesis server is already running, defaults to false)')
+  console.log('--num-records (number of records to grab from kinesis, defaults to no limit)')
   process.exit()
 }
 
@@ -70,7 +72,8 @@ var opts = {
   localDynamo: !! args['local-dynamo'],
   localKinesis: !! args['local-kinesis'],
   localKinesisPort: args['local-kinesis-port'],
-  logLevel: args['log-level']
+  logLevel: args['log-level'],
+  numRecords: args['num-records']
 }
 
 logger.info('Consumer app path:', consumer)


### PR DESCRIPTION
The reason for this PR is that I need to limit the number of records that I am retrieving from kinesis each iteration as there is a lot of "work" associated with processing each record which means that grabbing 5000+ records each processRecords call is not really feasible.   If num-records is not specified then the functionality remains the same - otherwise the `num-records` CLI parameter will limit the number of records retrieved.