### PR TITLE
Add 'metrics' callback to Kinesis consumer interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "async": "^0.9.0",
-    "aws-sdk": "^2.0.29",
+    "aws-sdk": "^2.1.38",
     "bunyan": "^1.2.3",
     "kinesalite": "^1.0.2",
     "local-dynamo": "0.0.3",

--- a/tsd.json
+++ b/tsd.json
@@ -6,28 +6,28 @@
   "bundle": "build/.typings/tsd.d.ts",
   "installed": {
     "aws-sdk/aws-sdk.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "async/async.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "underscore/underscore.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "node/node.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "bunyan/bunyan.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "minimist/minimist.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "mkdirp/mkdirp.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "vogels/vogels.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     }
   }
 }


### PR DESCRIPTION
This adds an optional metrics callback.

The only metric sent is MillisBehindLatest which can be tracked to gauge if the
processor is falling behind and the app needs to be scaled.

Doing it this way makes this a non-breaking change and allows additional
metrics to be sent to the callback in the future without breaking it.  For
example, another metric might be how long the GetRecords call took.