### PR TITLE
allow client to override processResponse or processRecords

### DIFF
--- a/src/AbstractConsumer.ts
+++ b/src/AbstractConsumer.ts
@@ -31,8 +31,8 @@ export interface ProcessRecordsCallback {
 }
 
 export interface ConsumerExtension {
-  processResponse: (request: AWS.kinesis.GetRecordsResult, callback: ProcessRecordsCallback) => void
-  processRecords: (records: AWS.kinesis.Record[], callback: ProcessRecordsCallback) => void
+  processResponse?: (request: AWS.kinesis.GetRecordsResult, callback: ProcessRecordsCallback) => void
+  processRecords?: (records: AWS.kinesis.Record[], callback: ProcessRecordsCallback) => void
   initialize?: (callback: (err?: any) => void) => void
   shutdown?: (callback: (err?: any) => void) => void
 }

--- a/tsd.json
+++ b/tsd.json
@@ -6,28 +6,28 @@
   "bundle": "build/.typings/tsd.d.ts",
   "installed": {
     "aws-sdk/aws-sdk.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "async/async.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "underscore/underscore.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "node/node.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "bunyan/bunyan.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "minimist/minimist.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "mkdirp/mkdirp.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     },
     "vogels/vogels.d.ts": {
-      "commit": "50ec9ed6e4ac8a6b78dbb3bb15deaf2f9ea7e098"
+      "commit": "1cdb0112fcab7ad7d85a5feebd9f02dcf3dccc32"
     }
   }
 }


### PR DESCRIPTION
processResponse - allows access to aws kinesis response
processRecords - allows access to just records for a simpler client interface