### PR TITLE
Block on parent shard if parent shard has events to be processed

### DIFF
--- a/src/ConsumerCluster.ts
+++ b/src/ConsumerCluster.ts
@@ -317,11 +317,15 @@ export class ConsumerCluster extends EventEmitter {
 
         // skip if parent shard is not finished (split case)
         if (shardInfo.ParentShardId && !(finishedShardIds.indexOf(shardInfo.ParentShardId) >= 0)) {
+          this.logger.info({ ParentShardId: shardInfo.ParentShardId, ShardId :  shardInfo.ShardId}, 
+                            'Ignoring shard because ParentShardId is not finished')
           return false
         }
 
         // skip if adjacent parent shard is not finished (merge case)
         if (shardInfo.AdjacentParentShardId && !(finishedShardIds.indexOf(shardInfo.AdjacentParentShardId) >= 0)) {
+          this.logger.info({ AdjacentParentShardId: shardInfo.AdjacentParentShardId, ShardId :  shardInfo.ShardId}, 
+                            'Ignoring shard because AdjacentParentShardId is not finished')
           return false
         }
 


### PR DESCRIPTION
 Ignore new shards (created as a result of merge/split) if the current iterator on the parent shard is lagging (i.e behind the tip of the shard)

As soon as the parents have been processed, workers are spawned for the new shards