### PR TITLE
Use polling to speed up the tests

### DIFF
--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   kinesalite: require('./kinesalite'),
   consumer: require('./consumer'),
-  fixtures: require('./fixtures')
+  fixtures: require('./fixtures'),
+  poll: require('./poll')
 }

--- a/test/helpers/poll.js
+++ b/test/helpers/poll.js
@@ -1,0 +1,19 @@
+module.exports = poll
+
+function poll (fn, timeout, interval) {
+  let endTime = Number(new Date()) + (timeout || 200)
+  interval = interval || 10
+
+  let checkCondition = function (resolve, reject) {
+    const result = fn()
+    if (result) {
+      resolve(result)
+    } else if (Number(new Date()) < endTime) {
+      setTimeout(checkCondition, interval, resolve, reject)
+    } else {
+      reject(new Error('timed out for ' + fn + ': ' + arguments))
+    }
+  }
+
+  return new Promise(checkCondition)
+}

--- a/test/index.js
+++ b/test/index.js
@@ -61,11 +61,20 @@ describe('Kinesis Client Library', function () {
       stdout += chunk
     })
 
-    // Give an arbitrarily large amount of time for all the consumers to spin up
-    setTimeout(function () {
+    function getCurrentlyReadLyricsLength () {
       var lyrics = stdout.match(/Line: /g)
-      assert.equal(lyrics.length, helpers.fixtures.records.length, 'Write one line per lyric')
-      done()
-    }, 30000)
+      return lyrics ? lyrics.length : 0
+    }
+
+    let lyricsLength = 0
+    helpers.poll(() => {
+      lyricsLength = getCurrentlyReadLyricsLength()
+      return lyricsLength === helpers.fixtures.records.length
+    }, 30000, 100)
+      .then(() => {
+        assert.equal(lyricsLength, helpers.fixtures.records.length, 'Write one line per lyric')
+        done()
+      })
+      .catch(() => done('Timed out waiting for lyrics to be read.'))
   })
 })


### PR DESCRIPTION
Use polling to avoid unnecessary waiting time on the test. Running locally, the tests now take 10 seconds, down from 30 seconds.